### PR TITLE
Start cron daemon for automatic renewal of certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,18 @@ LABEL maintainer="Miguel Pérez <https://github.com/mperezi>"
 
 RUN printf "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list && \
 	apt-get update && \
-	apt-get -y install certbot python-certbot-apache -t stretch-backports
+	apt-get -y install certbot python-certbot-apache cron rsyslog -t stretch-backports
 
+# Add periodic renew task of certificates
+RUN crontab /etc/cron.d/certbot
+
+# Enable cron logs via rsyslog
+RUN sed -i \
+    -e 's,^#\(cron.*\)$,\1,' \
+    -e 's,^\(module.*imklog.*\)$,#\1,' \
+    /etc/rsyslog.conf
+
+# Enable HTTPS support in Apache
 RUN sed -i \
 	-e 's/^#\(LoadModule .*mod_ssl.so\)/\1/' \
 	-e 's/^#\(LoadModule .*mod_socache_shmcb.so\)/\1/' \

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+service cron start
+service rsyslog start
+
 echo "Checking certificates"
 if [ ! -e /etc/letsencrypt/live/$(hostname -f)/privkey.pem ]; then
 	echo "No certificate found for $(hostname -f)"


### PR DESCRIPTION
Renewal of certificates was being done only as part of the container start-up.
